### PR TITLE
Update server comment

### DIFF
--- a/chat-server/server.js
+++ b/chat-server/server.js
@@ -216,7 +216,7 @@ REMEMBER: If a user asks about anything outside of this data, politely respond t
     }
 });
 
-// Update the config endpoint to use hardcoded production URL or fall back to .env
+// Return chat API URL based on NODE_ENV (production vs. local)
 app.get('/api/config', (req, res) => {
   const apiUrl = process.env.NODE_ENV === 'production' 
     ? 'https://mywebsite-jvhz.onrender.com/api/chat'  // Production URL


### PR DESCRIPTION
## Summary
- clarify that config URL choice uses `NODE_ENV`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685357a1db34832eabb46a41ae49a25a